### PR TITLE
Bump version from 0.1.0 to 0.1.0+build.1

### DIFF
--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.1.0"
+__version__ = "0.1.0+build.1"


### PR DESCRIPTION
Bumping the version so I can re-release, pulling in the code from cisagov/ansible-role-cloudwatch-agent#2.

I recreated this PR since I previously updated the patch number.  I realized that this wasn't the correct thing to do in this case, since no code in _this_ project has changed.  Hence this redo with the build number incremented.