### PR TITLE
Upgrade base AMI to Fedora 38

### DIFF
--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -134,9 +134,10 @@ build {
   sources = ["source.amazon-ebs.freeipa"]
 
   provisioner "ansible" {
-    playbook_file = "src/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    extra_arguments = ["-vvvv"]
+    playbook_file   = "src/upgrade.yml"
+    use_proxy       = false
+    use_sftp        = true
   }
 
   provisioner "ansible" {

--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -73,9 +73,9 @@ variable "skip_create_ami" {
   type        = bool
 }
 
-data "amazon-ami" "fedora_37" {
+data "amazon-ami" "fedora_38" {
   filters = {
-    name                = "Fedora-Cloud-Base-37-*x86_64-hvm-*-gp2-*"
+    name                = "Fedora-Cloud-Base-38-*x86_64-hvm-*-gp2-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
@@ -103,7 +103,7 @@ source "amazon-ebs" "freeipa" {
   region             = var.build_region
   region_kms_key_ids = var.region_kms_keys
   skip_create_ami    = var.skip_create_ami
-  source_ami         = data.amazon-ami.fedora_37.id
+  source_ami         = data.amazon-ami.fedora_38.id
   ssh_username       = "fedora"
   subnet_filter {
     filters = {
@@ -112,9 +112,9 @@ source "amazon-ebs" "freeipa" {
   }
   tags = {
     Application        = "FreeIPA server"
-    Base_AMI_Name      = data.amazon-ami.fedora_37.name
+    Base_AMI_Name      = data.amazon-ami.fedora_38.name
     GitHub_Release_URL = var.release_url
-    OS_Version         = "Fedora 37"
+    OS_Version         = "Fedora 38"
     Pre_Release        = var.is_prerelease
     Release            = var.release_tag
     Team               = "VM Fusion - Development"


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the base AMI to Fedora 38.

## 💭 Motivation and context ##

In order to have all the latest security fixes and improvements, it makes sense to always use the latest Fedora release for the base AMI.

## 🧪 Testing ##

All automated tests pass.  I also built a new COOL staging with these changes and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.
- [ ] Build and test a staging AMI with these changes.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.